### PR TITLE
Fixed error temp sent twice + added delimiter

### DIFF
--- a/Software/MarvinBase_temp_humid_sensor/MarvinBase_temp_humid_sensor.ino
+++ b/Software/MarvinBase_temp_humid_sensor/MarvinBase_temp_humid_sensor.ino
@@ -76,7 +76,7 @@ void loop() {
     }
   int temp = (int) h;
   int hum = (int) t;  
-  send_LoRa_data(set_port, String(temp) + String(temp));
+  send_LoRa_data(set_port, String(temp) + "F" + String(hum)); // use "F" as delimited between temp en hum value so you can split again
   blinky();
   delay(1000);
   read_data_from_LoRa_Mod();


### PR DESCRIPTION
The temperature was sent twice, fixed so temp and humidity are being sent.
Also added delimiter between te two values, because, although humidity usually is 2 digits, it is better not to rely on that.
Since the delimiter had to be an acceptable HEX value I choose "F"